### PR TITLE
#100 & #88 Add Points of Contact

### DIFF
--- a/deploy/ml-config.xml
+++ b/deploy/ml-config.xml
@@ -226,7 +226,7 @@
         <range-element-index>
           <scalar-type>string</scalar-type>
           <namespace-uri>http://marklogic.com/xdmp/json/basic</namespace-uri>
-          <localname>maintainer</localname>
+          <localname>personName</localname>
           <collation>http://marklogic.com/collation/codepoint</collation>
           <range-value-positions>false</range-value-positions>
         </range-element-index>

--- a/rest-api/config/options/all.xml
+++ b/rest-api/config/options/all.xml
@@ -32,9 +32,9 @@
       <search:facet-option>frequency-order</search:facet-option>
     </search:range>
   </search:constraint>
-  <search:constraint name="maintainer">
+  <search:constraint name="personName">
     <search:range type="xs:string" collation="http://marklogic.com/collation/codepoint" facet="true">
-      <search:element ns="http://marklogic.com/xdmp/json/basic" name="maintainer"/>
+      <search:element ns="http://marklogic.com/xdmp/json/basic" name="personName"/>
       <search:facet-option>limit=10</search:facet-option>
       <search:facet-option>frequency-order</search:facet-option>
     </search:range>

--- a/rest-api/ext/comment.xqy
+++ b/rest-api/ext/comment.xqy
@@ -45,12 +45,12 @@ function comment:post(
   (: BEGIN send notification :)
   (: get demo info :)
   let $demo := fn:doc($uri)/jbasic:json
-  (: get maintainer name :)
+  (: get demo name :)
   let $demo-name as xs:string? := $demo/jbasic:name
-  (: get maintainer name :)
-  let $maintainer-name as xs:string? := $demo/jbasic:maintainer
-  (: get maintainer email :)
-  let $maintainer-email as xs:string? := $demo/jbasic:email
+  (: get business owner name :)
+  let $biz-owner-name as xs:string? := $demo/jbasic:persons/jbasic:json[jbasic:role = "Business Owner"]/jbasic:name
+  (: get business owner email :)
+  let $biz-owner-email as xs:string? := $demo/jbasic:persons/jbasic:json[jbasic:role = "Business Owner"]/jbasic:email
   (: get referring host :)
   let $host := utilities:get-referring-host()
   (: build message :)
@@ -62,7 +62,7 @@ function comment:post(
     </div>
 
   return (
-    utilities:send-notification($maintainer-name, $maintainer-email, '[DemoCat] New Comment for "'||$demo-name||'"', $message),
+    utilities:send-notification($biz-owner-name, $biz-owner-email, '[DemoCat] New Comment for "'||$demo-name||'"', $message),
     xdmp:set-response-code(200, "OK"),
     document { json:transform-to-json($populated-xml) }
   )

--- a/rest-api/ext/file-bug.xqy
+++ b/rest-api/ext/file-bug.xqy
@@ -44,12 +44,12 @@ function file-bug:post(
   (: BEGIN send notification :)
   (: get demo info :)
   let $demo := fn:doc($uri)/jbasic:json
-  (: get maintainer name :)
+  (: get demo name :)
   let $demo-name as xs:string? := $demo/jbasic:name
-  (: get maintainer name :)
-  let $maintainer-name as xs:string? := $demo/jbasic:maintainer
-  (: get maintainer email :)
-  let $maintainer-email as xs:string? := $demo/jbasic:email
+  (: get technical contact name :)
+  let $tech-contact-name as xs:string? := $demo/jbasic:persons/jbasic:json[jbasic:role = "Technical Contact"]/jbasic:name
+  (: get technical contact email :)
+  let $tech-contact-email as xs:string? := $demo/jbasic:persons/jbasic:json[jbasic:role = "Technical Contact"]/jbasic:email
   (: get bug type - defect or enhancement :)
   let $bug-type as xs:string? := $json-xml/jbasic:type
   (: get referring host :)
@@ -62,7 +62,7 @@ function file-bug:post(
       <div>{$populated-xml/jbasic:msg/node()}</div>
     </div>
   return (
-    utilities:send-notification($maintainer-name, $maintainer-email, '[DemoCat] New Bug for "'||$demo-name||'"', $message),
+    utilities:send-notification($tech-contact-name, $tech-contact-email, '[DemoCat] New Bug for "'||$demo-name||'"', $message),
     xdmp:set-response-code(200, "OK"),
     document { json:transform-to-json($populated-xml) }
   )

--- a/src/data-migration/maintainer-to-tech-contact.xqy
+++ b/src/data-migration/maintainer-to-tech-contact.xqy
@@ -1,0 +1,56 @@
+declare namespace jbasic = "http://marklogic.com/xdmp/json/basic";
+
+for $doc in xdmp:directory("/demos/", "infinity")
+let $current-maintainer := $doc/jbasic:json/jbasic:maintainer
+let $current-email := $doc/jbasic:json/jbasic:email
+let $current-role := "Technical Contact"
+let $persons :=
+  if($current-maintainer or $current-email) then
+    element jbasic:persons {
+      attribute type { "array"},
+      element jbasic:json {
+        attribute type { "object"},
+        if($current-maintainer) then
+          element jbasic:personName {
+            attribute type { "string"},
+            $current-maintainer/text()
+          }
+        else
+          ()
+        ,
+        if($current-email) then
+          element jbasic:email {
+            attribute type { "string"},
+            $current-email/text()
+          }
+        else
+          ()
+        ,
+        element jbasic:role {
+          attribute type { "string"},
+          $current-role
+        }
+      }
+    }
+  else
+    ()
+
+let $op :=
+  if($persons) then
+    let $ins := xdmp:node-insert-child($doc/jbasic:json, $persons)
+    return
+      let $del :=
+        if($current-email) then
+          xdmp:node-delete($current-email)
+        else
+          ()
+      let $del :=
+        if($current-maintainer) then
+          xdmp:node-delete($current-maintainer)
+        else
+         ()
+      return $del
+  else
+    ()
+
+return fn:concat("Updated maintainer for ", fn:document-uri($doc))

--- a/ui/app/scripts/controllers/create.js
+++ b/ui/app/scripts/controllers/create.js
@@ -18,12 +18,14 @@
           languages: [],
           bugs: [],
           comments: [],
-          credentials: []
+          credentials: [],
+          persons: []
         },
         edit: edit,
         featureChoices: features.list(),
         domainChoices: domains.list(),
         browserChoices: ['Firefox', 'Chrome', 'IE'],
+        personRoleChoices: ['Technical Contact', 'Business Owner', 'External Contact'],
         user: user // GJo: a bit blunt way to insert the User service, but seems to work
       };
 
@@ -55,6 +57,12 @@
         },
         removeCredentials: function(index) {
           model.demo.credentials.splice(index, 1);
+        },
+        addPerson: function() {
+          model.demo.persons.push({personName: null, role: null, email: null});
+        },
+        removePerson: function(index) {
+          model.demo.persons.splice(index, 1);
         },
         submit: function() {
           var promise;

--- a/ui/app/views/create.html
+++ b/ui/app/views/create.html
@@ -68,12 +68,30 @@
       </div>
     </div>
     <div class="form-group">
-      <label class="col-sm-2 control-label">Maintainer</label>
-      <div class="col-sm-5">
-        <input type="text" class="form-control" placeholder="Pat Fixer" ng-model="model.demo.maintainer">
-      </div>
-      <div class="col-sm-5">
-        <input type="email" class="form-control" placeholder="pat.fixer@marklogic.com" ng-model="model.demo.email">
+      <label class="col-sm-2 control-label">Points of Contact</label>
+      <button class="btn btn-primary btn-xs" ng-click="addPerson()">
+        <span class="glyphicon glyphicon-plus"></span> Add
+      </button>
+    </div>
+    <div class="form-group">
+      <div ng-repeat="person in model.demo.persons" class="col-sm-10 col-sm-offset-2">
+        <label class="col-sm-1 control-label">Role</label>
+        <div class="col-sm-2">
+          <select ng-options="role for role in model.personRoleChoices" ng-model="person.role">
+            <option value="" disabled>Choose role</option>
+          </select>
+        </div>
+        <label class="col-sm-1 control-label">Name</label>
+        <div class="col-sm-2">
+          <input type="text" class="form-control" ng-model="person.personName">
+        </div>
+        <label class="col-sm-1 control-label">Email</label>
+        <div class="col-sm-2">
+          <input type="text" class="form-control" ng-model="person.email">
+        </div>
+        <button class="btn btn-default" ng-click="removePerson($index)">
+          <span class="glyphicon glyphicon-remove"></span>
+        </button>
       </div>
     </div>
     <div class="form-group">

--- a/ui/app/views/demo.html
+++ b/ui/app/views/demo.html
@@ -31,9 +31,14 @@
     <span class="value">{{model.demo.repo}}</span>
   </div>
   <div class="maintainer col-md-12">
-    <label>Maintainer</label>
-    <span class="value">{{model.demo.maintainer}}</span>
-    (<a ng-href="mailto:{{model.demo.email}}">{{model.demo.email}}</a>)
+    <label>Points of Contact</label>
+    <ul>
+      <li ng-repeat="person in model.demo.persons">
+        <label>{{person.role}}</label>
+        <span class="value">{{person.personName}}</span>
+        (<a ng-href="mailto:{{person.email}}">{{person.email}}</a>)
+      </li>
+    </ul>
   </div>
   <div class="version col-md-12">
     <label>MarkLogic version</label>


### PR DESCRIPTION
   #100 & #88 Add Points of Contact
    
    Add a new persons array to a demo, displayed as Points of Contact .
    Allow three roles: Technical Contact, Business Owner, External Contact.
     This supports n number of persons with n number of roles.
    
    Migrate current maintainer and email to that of a Technical Contact.
    Provided XQuery module maintainer-to-tech-contact.xqy will preform this
    migration.
    
    Remove maintainer element range index and replace with that for a
    personName.  Update search options for new facet.
    
    Update the emails sent to the appropriate person: Technical Contact for
    bug and Business Owner for comment.