### PR TITLE
#90 Follow a demo

### DIFF
--- a/deploy/app_specific.rb
+++ b/deploy/app_specific.rb
@@ -10,7 +10,7 @@ class ServerConfig
     original_deploy_modules
     r = execute_query %Q{
       xquery version "1.0-ml";
-      
+
       for $uri in cts:uris()
       return (
         $uri,
@@ -36,7 +36,7 @@ class ServerConfig
           raise ExitException.new("Upgrade to Ruby >= 1.9 for prompting on the shell.")
         end
       end
-      
+
       if (@properties["ml.ldap-password"] == "") then
         if STDIN.respond_to?(:noecho)
         print "Enter an LDAP password: "
@@ -47,19 +47,19 @@ class ServerConfig
         end
       end
     end
-    
+
     original_bootstrap
   end
-  
+
   # adjust REST security to allow deploy
   alias_method :original_deploy_rest, :deploy_rest
   def deploy_rest()
     if (@properties["ml.internal-security"] == "false")
       r = execute_query %Q{
-        xquery version "1.0-ml"; 
-      
+        xquery version "1.0-ml";
+
         import module namespace admin = "http://marklogic.com/xdmp/admin" at "/MarkLogic/admin.xqy";
-      
+
         let $config := admin:get-configuration()
         let $config := admin:appserver-set-internal-security($config, xdmp:server("#{@properties["ml.app-name"]}"), fn:true())
         return
@@ -67,15 +67,15 @@ class ServerConfig
       },
       { :app_name => @properties["ml.app-name"] }
     end
-    
+
     original_deploy_rest
-    
+
     if (@properties["ml.internal-security"] == "false")
       r = execute_query %Q{
-        xquery version "1.0-ml"; 
-      
+        xquery version "1.0-ml";
+
         import module namespace admin = "http://marklogic.com/xdmp/admin" at "/MarkLogic/admin.xqy";
-      
+
         let $config := admin:get-configuration()
         let $config := admin:appserver-set-internal-security($config, xdmp:server("#{@properties["ml.app-name"]}"), fn:false())
         return
@@ -84,19 +84,19 @@ class ServerConfig
       { :app_name => @properties["ml.app-name"] }
     end
   end
-  
+
   def migrate_data()
     fix_permissions()
     fix_credentials()
     fix_contacts()
   end
-  
+
   # fix content permissions
   def fix_permissions()
     logger.info "Fixing permissions.."
     r = execute_query %Q{
       xquery version "1.0-ml";
-      
+
       for $uri in cts:uris()
       return (
         $uri,
@@ -108,35 +108,125 @@ class ServerConfig
       )
     },
     { :app_name => @properties["ml.app-name"] }
-    
+
     r.body = parse_json r.body
     logger.debug r.body
   end
-  
+
   def fix_credentials()
     logger.info "Fixing credentials.."
     r = execute_query %Q{
       xquery version "1.0-ml";
-      
+
       xdmp:invoke("/data-transforms/add-credentials.xqy")
     },
     { :app_name => @properties["ml.app-name"] }
-    
+
     r.body = parse_json r.body
     logger.info r.body
   end
-  
+
   def fix_contacts()
     logger.info "Fixing contacts.."
     r = execute_query %Q{
       xquery version "1.0-ml";
-      
+
       xdmp:invoke("/data-migration/maintainer-to-tech-contact.xqy")
     },
     { :app_name => @properties["ml.app-name"] }
-    
+
     r.body = parse_json r.body
     logger.info r.body
   end
-  
+
+  def remove_alerting ()
+    r = execute_query %Q{
+
+      (: First delete the original triggers configuration so we can set it up newly :)
+      xquery version "1.0-ml";
+      import module namespace alert = "http://marklogic.com/xdmp/alert" at "/MarkLogic/alert.xqy";
+
+      try {
+        let $config := alert:config-get("http://marklogic.com/demo-cat/notifications")
+        return if (fn:empty($config))
+          then ()
+          else alert:remove-triggers("http://marklogic.com/demo-cat/notifications")
+      } catch ($e) {
+        xdmp:log($e)
+      };
+
+
+      (: Then delete the original alerting configuration so we can set it up newly :)
+      xquery version "1.0-ml";
+      import module namespace alert = "http://marklogic.com/xdmp/alert" at "/MarkLogic/alert.xqy";
+
+      try {
+        let $config := alert:config-get("http://marklogic.com/demo-cat/notifications")
+        return if (fn:empty($config))
+          then ()
+          else alert:config-delete("http://marklogic.com/demo-cat/notifications")
+      } catch ($e) {
+        xdmp:log($e)
+      };
+    },
+    { :app_name => @properties["ml.app-name"] }
+  end
+
+    # setup_alerting is used to define the alerting used for notifications
+  def setup_alerting ()
+    remove_alerting
+
+    r = execute_query %Q{
+
+      (: Create the alerting configuration :)
+      xquery version "1.0-ml";
+      import module namespace alert = "http://marklogic.com/xdmp/alert" at "/MarkLogic/alert.xqy";
+
+      let $config := alert:make-config(
+            "http://marklogic.com/demo-cat/notifications",
+            "Notifications",
+            "Alerting configuration for creating notifications",
+              <alert:options/> )
+
+      return alert:config-insert($config);
+
+      (: Create the trigger and associate it with the config :)
+      xquery version "1.0-ml";
+      import module namespace alert = "http://marklogic.com/xdmp/alert" at "/MarkLogic/alert.xqy";
+      import module namespace trgr="http://marklogic.com/xdmp/triggers" at "/MarkLogic/triggers.xqy";
+
+
+      let $trigger-ids := alert:create-triggers(
+        "http://marklogic.com/demo-cat/notifications",
+        trgr:trigger-data-event(
+          trgr:directory-scope('/demos/', 'infinity'),
+          trgr:document-content(("modify")),
+          trgr:post-commit()
+        )
+      )
+
+      return alert:config-insert(
+               alert:config-set-trigger-ids(
+                  alert:config-get("http://marklogic.com/demo-cat/notifications"),
+                  $trigger-ids));
+
+
+      (: Connect the send email action to the alerting configuration :)
+      xquery version "1.0-ml";
+      import module namespace alert = "http://marklogic.com/xdmp/alert" at "/MarkLogic/alert.xqy";
+
+      let $action := alert:make-action(
+          "send-demo-email",
+          "Send an email when a demo is updated",
+          xdmp:database('#{@properties["ml.modules-db"]}'),
+          '/',
+          "/alerting/alert-send-demo-email.xqy",
+          <alert:options/> )
+      return alert:action-insert("http://marklogic.com/demo-cat/notifications", $action);
+
+      (: Consider adding any one-off Alerting rules here. :)
+
+      },
+     { :db_name => @properties["ml.content-db"] }
+   end
 end

--- a/deploy/build.properties
+++ b/deploy/build.properties
@@ -46,7 +46,7 @@ modules-root=/
 # Leave commented out for default
 # turn it on if you are using triggers or CPF
 #
-# triggers-db=${app-name}-triggers
+triggers-db=${app-name}-triggers
 
 #
 # the port that the Docs appserver is running on

--- a/deploy/ml-config.xml
+++ b/deploy/ml-config.xml
@@ -400,7 +400,7 @@
       <word-searches>false</word-searches>
       <word-positions>false</word-positions>
       <fast-phrase-searches>false</fast-phrase-searches>
-      <fast-reverse-searches>false</fast-reverse-searches>
+      <fast-reverse-searches>true</fast-reverse-searches>
       <fast-case-sensitive-searches>false</fast-case-sensitive-searches>
       <fast-diacritic-sensitive-searches>false</fast-diacritic-sensitive-searches>
       <fast-element-word-searches>false</fast-element-word-searches>
@@ -493,6 +493,7 @@
         <role-name>@ml.app-name-execute-role</role-name>
         <!-- necessary to make sure profile is readably to users with reader-role -->
         <role-name>@ml.app-name-defaults-role</role-name>
+        <role-name>alert-user</role-name>
       </role-names>
       <privileges>
         <privilege>
@@ -558,6 +559,7 @@
       <description>A role for admin users of the @ml.app-name application</description>
       <role-names>
         <role-name>@ml.app-name-writer-role</role-name>
+        <role-name>alert-admin</role-name>
       </role-names>
       <privileges>
         <privilege>

--- a/deploy/ml-config.xml
+++ b/deploy/ml-config.xml
@@ -401,7 +401,7 @@
       <word-searches>false</word-searches>
       <word-positions>false</word-positions>
       <fast-phrase-searches>false</fast-phrase-searches>
-      <fast-reverse-searches>true</fast-reverse-searches>
+      <fast-reverse-searches>false</fast-reverse-searches>
       <fast-case-sensitive-searches>false</fast-case-sensitive-searches>
       <fast-diacritic-sensitive-searches>false</fast-diacritic-sensitive-searches>
       <fast-element-word-searches>false</fast-element-word-searches>

--- a/deploy/ml-config.xml
+++ b/deploy/ml-config.xml
@@ -158,6 +158,7 @@
       <collection-lexicon>true</collection-lexicon>
       <directory-creation>manual</directory-creation>
       <maintain-last-modified>false</maintain-last-modified>
+      <fast-reverse-searches>true</fast-reverse-searches>
 <!--
       <fragment-roots>
         <fragment-root>

--- a/rest-api/ext/follow.xqy
+++ b/rest-api/ext/follow.xqy
@@ -1,0 +1,70 @@
+xquery version "1.0-ml";
+
+module namespace follow = "http://marklogic.com/rest-api/resource/follow";
+
+declare namespace roxy = "http://marklogic.com/roxy";
+
+(: 
+ : To add parameters to the functions, specify them in the params annotations. 
+ : Example
+ :   declare %roxy:params("uri=xs:string", "priority=xs:int") follow:get(...)
+ : This means that the get function will take two parameters, a string and an int.
+ :)
+
+(:
+ :)
+declare 
+%roxy:params("")
+function follow:get(
+  $context as map:map,
+  $params  as map:map
+) as document-node()*
+{
+  map:put($context, "output-types", "application/xml"),
+  xdmp:set-response-code(200, "OK"),
+  document { "GET called on the ext service extension" }
+};
+
+(:
+ :)
+declare 
+%roxy:params("")
+function follow:put(
+    $context as map:map,
+    $params  as map:map,
+    $input   as document-node()*
+) as document-node()?
+{
+  map:put($context, "output-types", "application/xml"),
+  xdmp:set-response-code(200, "OK"),
+  document { "PUT called on the ext service extension" }
+};
+
+(:
+ :)
+declare 
+%roxy:params("")
+function follow:post(
+    $context as map:map,
+    $params  as map:map,
+    $input   as document-node()*
+) as document-node()*
+{
+  map:put($context, "output-types", "application/xml"),
+  xdmp:set-response-code(200, "OK"),
+  document { "POST called on the ext service extension" }
+};
+
+(:
+ :)
+declare 
+%roxy:params("")
+function follow:delete(
+    $context as map:map,
+    $params  as map:map
+) as document-node()?
+{
+  map:put($context, "output-types", "application/xml"),
+  xdmp:set-response-code(200, "OK"),
+  document { "DELETE called on the ext service extension" }
+};

--- a/rest-api/ext/follow.xqy
+++ b/rest-api/ext/follow.xqy
@@ -5,6 +5,7 @@ module namespace follow = "http://marklogic.com/rest-api/resource/follow";
 import module namespace alert = "http://marklogic.com/xdmp/alert" at "/MarkLogic/alert.xqy";
 import module namespace json = "http://marklogic.com/xdmp/json" at "/MarkLogic/json/json.xqy";
 import module namespace json-helper = "http://marklogic.com/demo-cat/json-helper" at "/lib/json-helper.xqy";
+import module namespace utilities =  "http://marklogic.com/demo-cat/utilities" at "/lib/utilities.xqy";
 
 declare namespace roxy = "http://marklogic.com/roxy";
 declare namespace jbasic = "http://marklogic.com/xdmp/json/basic";
@@ -28,7 +29,7 @@ function follow:get(
 {
   map:put($context, "output-types", "application/json"),
   xdmp:set-response-code(501, "OK"),
-  document { "GET called on the ext service extension" }
+  document { "Not implemented" }
 };
 
 (:
@@ -43,7 +44,7 @@ function follow:put(
 {
   map:put($context, "output-types", "application/json"),
   xdmp:set-response-code(501, "OK"),
-  document { "PUT called on the ext service extension" }
+  document { "Not implemented" }
 };
 
 (:
@@ -62,7 +63,10 @@ function follow:post(
   let $username := xdmp:get-current-user()
   let $profile-uri := fn:concat("/users/",$username,".json")
   let $profile := fn:doc($profile-uri)/jbasic:json
-  let $emails := $profile/jbasic:user/jbasic:emails/jbasic:item/data()
+  let $emails := $profile/jbasic:user/jbasic:emails/jbasic:item/string()
+  let $fullname := $profile/jbasic:user/jbasic:fullname/string()
+  let $host := utilities:get-referring-host()
+
 
   (: First add the rule.  We'll need the id :)
   let $rule := alert:make-rule(
@@ -72,6 +76,12 @@ function follow:post(
       cts:document-query($uri),
       "send-demo-email",
       element alert:options {
+        element alert:hostname {
+          $host
+        },
+        element alert:fullname {
+            $fullname
+          },
         for $email in $emails
          return
            element alert:email-address{
@@ -134,7 +144,6 @@ function follow:delete(
   let $delete := xdmp:node-delete($gone-node)
 
   return (
-    xdmp:log(("Deleted! ", $uri)),
     xdmp:set-response-code(200, "OK"),
     document { json:transform-to-json($gone-node)}
   )

--- a/rest-api/ext/follow.xqy
+++ b/rest-api/ext/follow.xqy
@@ -2,10 +2,16 @@ xquery version "1.0-ml";
 
 module namespace follow = "http://marklogic.com/rest-api/resource/follow";
 
-declare namespace roxy = "http://marklogic.com/roxy";
+import module namespace alert = "http://marklogic.com/xdmp/alert" at "/MarkLogic/alert.xqy";
+import module namespace json = "http://marklogic.com/xdmp/json" at "/MarkLogic/json/json.xqy";
+import module namespace json-helper = "http://marklogic.com/demo-cat/json-helper" at "/lib/json-helper.xqy";
 
-(: 
- : To add parameters to the functions, specify them in the params annotations. 
+declare namespace roxy = "http://marklogic.com/roxy";
+declare namespace jbasic = "http://marklogic.com/xdmp/json/basic";
+
+
+(:
+ : To add parameters to the functions, specify them in the params annotations.
  : Example
  :   declare %roxy:params("uri=xs:string", "priority=xs:int") follow:get(...)
  : This means that the get function will take two parameters, a string and an int.
@@ -13,21 +19,21 @@ declare namespace roxy = "http://marklogic.com/roxy";
 
 (:
  :)
-declare 
+declare
 %roxy:params("")
 function follow:get(
   $context as map:map,
   $params  as map:map
 ) as document-node()*
 {
-  map:put($context, "output-types", "application/xml"),
-  xdmp:set-response-code(200, "OK"),
+  map:put($context, "output-types", "application/json"),
+  xdmp:set-response-code(501, "OK"),
   document { "GET called on the ext service extension" }
 };
 
 (:
  :)
-declare 
+declare
 %roxy:params("")
 function follow:put(
     $context as map:map,
@@ -35,14 +41,14 @@ function follow:put(
     $input   as document-node()*
 ) as document-node()?
 {
-  map:put($context, "output-types", "application/xml"),
-  xdmp:set-response-code(200, "OK"),
+  map:put($context, "output-types", "application/json"),
+  xdmp:set-response-code(501, "OK"),
   document { "PUT called on the ext service extension" }
 };
 
 (:
  :)
-declare 
+declare
 %roxy:params("")
 function follow:post(
     $context as map:map,
@@ -50,21 +56,86 @@ function follow:post(
     $input   as document-node()*
 ) as document-node()*
 {
-  map:put($context, "output-types", "application/xml"),
-  xdmp:set-response-code(200, "OK"),
-  document { "POST called on the ext service extension" }
+  map:put($context, "output-types", "application/json"),
+  let $encoded-uri := map:get($params,"uri")
+  let $uri := xdmp:url-decode($encoded-uri)
+  let $username := xdmp:get-current-user()
+  let $profile-uri := fn:concat("/users/",$username,".json")
+  let $profile := fn:doc($profile-uri)/jbasic:json
+  let $emails := $profile/jbasic:user/jbasic:emails/jbasic:item/data()
+
+  (: First add the rule.  We'll need the id :)
+  let $rule := alert:make-rule(
+      "rule-send-email",
+      "The rule tests for an update to a demo",
+      xdmp:get-request-user(),
+      cts:document-query($uri),
+      "send-demo-email",
+      element alert:options {
+        for $email in $emails
+         return
+           element alert:email-address{
+             $email
+           }
+       })
+  let $rule-insert := alert:rule-insert("http://marklogic.com/demo-cat/notifications", $rule)
+  let $alert-id := $rule/@id
+
+  (: Construct the JSON for the user's profile :)
+  let $follow-object :=
+    element jbasic:json {
+      attribute type { "object"},
+      element jbasic:followUri {
+        attribute type { "string"},
+        $encoded-uri
+      },
+      element jbasic:followAlertId {
+        attribute type { "string"},
+        $alert-id/data()
+      }
+    }
+
+  (: Now insert the following info into the user's profile :)
+  let $insert-noop :=
+    if($profile/jbasic:user/jbasic:follows) then
+      xdmp:node-insert-child($profile/jbasic:user/jbasic:follows, $follow-object)
+    else
+      let $insert-node :=
+        element jbasic:follows {
+          attribute type { "array"},
+          $follow-object
+        }
+      return xdmp:node-insert-child($profile/jbasic:user, $insert-node)
+
+  return (
+    xdmp:set-response-code(200, "OK"),
+    document { json:transform-to-json($follow-object)}
+  )
 };
 
 (:
  :)
-declare 
+declare
 %roxy:params("")
 function follow:delete(
     $context as map:map,
     $params  as map:map
 ) as document-node()?
 {
-  map:put($context, "output-types", "application/xml"),
-  xdmp:set-response-code(200, "OK"),
-  document { "DELETE called on the ext service extension" }
+  map:put($context, "output-types", "application/json"),
+  let $uri := xdmp:url-decode(map:get($params,"uri"))
+  let $username := xdmp:get-current-user()
+  let $profile-uri := fn:concat("/users/",$username,".json")
+  let $profile := fn:doc($profile-uri)/jbasic:json
+
+  let $gone-node := $profile/jbasic:user/jbasic:follows/jbasic:json[jbasic:followUri = $uri]
+  let $alert-to-remove := $gone-node/jbasic:followAlertId/data()
+  let $removed := alert:rule-remove("http://marklogic.com/demo-cat/notifications",$alert-to-remove)
+  let $delete := xdmp:node-delete($gone-node)
+
+  return (
+    xdmp:log(("Deleted! ", $uri)),
+    xdmp:set-response-code(200, "OK"),
+    document { json:transform-to-json($gone-node)}
+  )
 };

--- a/rest-api/ext/user-login.xqy
+++ b/rest-api/ext/user-login.xqy
@@ -2,6 +2,9 @@ xquery version "1.0-ml";
 
 module namespace user = "http://marklogic.com/rest-api/resource/user-login";
 
+import module namespace json1="http://marklogic.com/xdmp/json" at "/MarkLogic/json/json.xqy";
+
+
 declare namespace roxy = "http://marklogic.com/roxy";
 
 (:
@@ -34,7 +37,8 @@ function user:get(
           return
             map:entry("profile", map:new((
               map:entry("fullname", $profile//*:fullname/data(.)),
-              map:entry("emails", json:to-array($profile//*:emails/*:item/data(.)))
+              map:entry("emails", json:to-array($profile//*:emails/*:item/data(.))),
+              map:entry("follows", json1:transform-to-json($profile//*:follows/*:json))
             )))
         ))
       )

--- a/rest-api/ext/user-login.xqy
+++ b/rest-api/ext/user-login.xqy
@@ -37,8 +37,7 @@ function user:get(
           return
             map:entry("profile", map:new((
               map:entry("fullname", $profile//*:fullname/data(.)),
-              map:entry("emails", json:to-array($profile//*:emails/*:item/data(.))),
-              map:entry("follows", json1:transform-to-json($profile//*:follows/*:json))
+              map:entry("emails", json:to-array($profile//*:emails/*:item/data(.)))
             )))
         ))
       )

--- a/rest-api/ext/user-status.xqy
+++ b/rest-api/ext/user-status.xqy
@@ -62,8 +62,7 @@ declare function user:get(
             map:entry("username", $current),
             map:entry("profile", map:new((
               map:entry("fullname", $profile//*:fullname/data(.)),
-              map:entry("emails", json:to-array($profile//*:emails/*:item/data(.))),
-              map:entry("follows", json1:transform-to-json($profile//*:follows/*:json))
+              map:entry("emails", json:to-array($profile//*:emails/*:item/data(.)))
             )))
           ))
         )

--- a/rest-api/ext/user-status.xqy
+++ b/rest-api/ext/user-status.xqy
@@ -3,6 +3,8 @@ xquery version "1.0-ml";
 module namespace user = "http://marklogic.com/rest-api/resource/user-status";
 
 import module namespace admin = "http://marklogic.com/xdmp/admin" at "/MarkLogic/admin.xqy";
+import module namespace json1="http://marklogic.com/xdmp/json" at "/MarkLogic/json/json.xqy";
+
 
 declare namespace roxy = "http://marklogic.com/roxy";
 
@@ -60,7 +62,8 @@ declare function user:get(
             map:entry("username", $current),
             map:entry("profile", map:new((
               map:entry("fullname", $profile//*:fullname/data(.)),
-              map:entry("emails", json:to-array($profile//*:emails/*:item/data(.)))
+              map:entry("emails", json:to-array($profile//*:emails/*:item/data(.))),
+              map:entry("follows", json1:transform-to-json($profile//*:follows/*:json))
             )))
           ))
         )

--- a/server.js
+++ b/server.js
@@ -133,6 +133,7 @@ exports.buildExpress = function(options) {
           if (json.user !== undefined) {
             req.session.user.profile.fullname = json.user.fullname;
             req.session.user.profile.emails = json.user.emails;
+            req.session.user.profile.follows = json.user.follows;
           }
           req.session.user.profile.webroles = json.webroles;
 
@@ -227,6 +228,14 @@ exports.buildExpress = function(options) {
   });
 
   app.post('/v1*', isWriter, function(req, res){
+    if (req.session.user === undefined) {
+      res.status(401).send('Unauthorized');
+    } else {
+      proxy(req, res);
+    }
+  });
+
+  app.delete('/v1/resources/follow*', function(req, res){
     if (req.session.user === undefined) {
       res.status(401).send('Unauthorized');
     } else {

--- a/src/alerting/alert-send-demo-email.xqy
+++ b/src/alerting/alert-send-demo-email.xqy
@@ -1,15 +1,36 @@
+(: An alert that sends an email when a demo has been updated :)
 xquery version "1.0-ml";
 
 
 declare namespace alert = "http://marklogic.com/xdmp/alert";
 
-import module namespace utilities =  "http://marklogic.com/demo-cat/utilities"
-  at "/lib/utilities.xqy";
+import module namespace utilities =  "http://marklogic.com/demo-cat/utilities" at "/lib/utilities.xqy";
+
+declare namespace jbasic = "http://marklogic.com/xdmp/json/basic";
+
 
 declare variable $alert:config-uri as xs:string external;
 declare variable $alert:doc as node() external;
 declare variable $alert:rule as element(alert:rule) external;
 declare variable $alert:action as element(alert:action) external;
 
-let $doc-uri := fn:document-uri($alert:doc)
-return xdmp:log("Alert received!")
+(: Get the info about what was updated :)
+let $title := $alert:doc/jbasic:json/jbasic:name/string()
+let $uri := fn:document-uri($alert:doc)
+
+(: Get the info about the user who followed this demo :)
+let $fullname := $alert:rule/alert:options/alert:fullname/string()
+let $emails := $alert:rule/alert:options/alert:email-address/string()
+
+(: Build and send the email :)
+let $hostname := $alert:rule/alert:options/alert:hostname/string()
+let $subject := fn:concat("[DemoCat] follow notification: ", $title, " has been updated")
+let $message :=
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <h2> {$title}, a demo you follow, has been updated. </h2>
+      <p> To see the updated demo, click "<a href="http://{$hostname}/detail?uri={xdmp:url-encode($uri)}">here</a>"</p>
+    </div>
+
+return
+  for $email in $emails
+  return utilities:send-notification($fullname, $email, $subject, $message)

--- a/src/alerting/alert-send-demo-email.xqy
+++ b/src/alerting/alert-send-demo-email.xqy
@@ -1,0 +1,15 @@
+xquery version "1.0-ml";
+
+
+declare namespace alert = "http://marklogic.com/xdmp/alert";
+
+import module namespace utilities =  "http://marklogic.com/demo-cat/utilities"
+  at "/lib/utilities.xqy";
+
+declare variable $alert:config-uri as xs:string external;
+declare variable $alert:doc as node() external;
+declare variable $alert:rule as element(alert:rule) external;
+declare variable $alert:action as element(alert:action) external;
+
+let $doc-uri := fn:document-uri($alert:doc)
+return xdmp:log("Alert received!")

--- a/ui/app/auth/auth-srv.js
+++ b/ui/app/auth/auth-srv.js
@@ -45,6 +45,14 @@
 
         user.isWriter = isWriter;
         user.isAdmin = isAdmin;
+
+        if (u.profile.follows) {
+          user.follows = u.profile.follows;
+        }
+        else {
+          // Start with an empty array if user isn't following a demo yet
+          user.follows = [];
+        }
       }
 
       function isWriter() {

--- a/ui/app/scripts/controllers/demo.js
+++ b/ui/app/scripts/controllers/demo.js
@@ -280,13 +280,53 @@
         saveMemos();
       },
       isFollowing: function() {
-        if(model.user.follows.indexOf(model.uri) > -1 ) {
+        var pos = model.user.follows.map(function(e) { return e.followUri; }).indexOf(model.uri);
+        if(pos > -1 ) {
           return true;
         }
         else {
           return false;
         }
 
+      },
+      follow: function() {
+        mlRest.callExtension('follow',
+            {
+              method: 'POST',
+              data: '',
+              params: {
+                'rs:uri': uri
+              },
+              headers: {
+                'Content-Type': 'application/json'
+              }
+            }
+          ).then(
+              function(result) {
+                // TODO: Check result
+                model.user.follows.push(result.data);
+              });
+
+      },
+      unfollow: function() {
+        mlRest.callExtension('follow',
+            {
+              method: 'DELETE',
+              data: '',
+              params: {
+                'rs:uri': uri
+              },
+              headers: {
+                'Content-Type': 'application/json'
+              }
+            }
+          ).then(
+              function(result) {
+                var toDelete = model.user.follows.map(function(e) { return e.followUri; }).indexOf(model.uri);
+                if(toDelete > -1) {
+                  model.user.follows.splice(toDelete, 1);
+                }
+              });
       }
 
     });

--- a/ui/app/scripts/controllers/demo.js
+++ b/ui/app/scripts/controllers/demo.js
@@ -252,7 +252,7 @@
           );
         }
       },
-      
+
       addMemo: function() {
         var memo = { title: null, body: null };
         showModal('/views/modals/edit-memo.html', 'New memo', memo, validateMemo)
@@ -278,9 +278,19 @@
       removeMemo: function(index) {
         model.demo.memos.splice(index, 1);
         saveMemos();
+      },
+      isFollowing: function() {
+        if(model.user.follows.indexOf(model.uri) > -1 ) {
+          return true;
+        }
+        else {
+          return false;
+        }
+
       }
+
     });
-    
+
     function validateMemo(memo) {
       var alerts = [];
       if (! memo.title) {
@@ -291,11 +301,11 @@
       }
       return alerts;
     }
-    
+
     function saveMemos(memo) {
       demoService.save(model.demo, uri);
     }
-    
+
     function showModal(template, title, model, validate) {
       return $modal.open({
         templateUrl: template+'',

--- a/ui/app/scripts/controllers/demo.js
+++ b/ui/app/scripts/controllers/demo.js
@@ -59,7 +59,8 @@
         //override default options
         toolbar: '',
         /* jshint camelcase: false */
-        toolbar_full: ''
+        toolbar_full: '',
+        followError: false
       },
       user: user
     };
@@ -290,22 +291,29 @@
 
       },
       follow: function() {
-        mlRest.callExtension('follow',
-            {
-              method: 'POST',
-              data: '',
-              params: {
-                'rs:uri': uri
-              },
-              headers: {
-                'Content-Type': 'application/json'
+        // Only allow the user to follow if they have set an email in their profile
+        if(model.user.emails && model.user.emails.length > 0){
+          mlRest.callExtension('follow',
+              {
+                method: 'POST',
+                data: '',
+                params: {
+                  'rs:uri': uri
+                },
+                headers: {
+                  'Content-Type': 'application/json'
+                }
               }
-            }
-          ).then(
-              function(result) {
-                // TODO: Check result
-                model.user.follows.push(result.data);
-              });
+            ).then(
+                function(result) {
+                  // TODO: Check result
+                  model.user.follows.push(result.data);
+                  model.followError = false;
+                });
+        }
+        else {
+          model.followError = true;
+        }
 
       },
       unfollow: function() {

--- a/ui/app/views/demo.html
+++ b/ui/app/views/demo.html
@@ -66,8 +66,10 @@
       <a class="btn btn-danger btn-xs btn-follow"  data-toggle="tooltip" title="Stop receiving emails when this demo is updated" ng-show="isFollowing()" ng-click="unfollow()">
         <i class="fa fa-envelope"></i> Unfollow this demo</a>
     </h2>
+    <div class="col-md-8">
+      <alert type="danger" ng-show="model.followError"> You must have an email set in your account to follow a demo. <a href="/profile">Set one up now.</a></alert>
+    </div>
     <div class="desc col-md-12" ng-bind-html="model.demo.description"></div>
-
     <div class="memos col-md-12">
       <h3>Memos</h3>
       <button class="btn btn-primary btn-sm" ng-show="model.user.isWriter()" ng-click="addMemo()">Add</button>

--- a/ui/app/views/demo.html
+++ b/ui/app/views/demo.html
@@ -60,9 +60,14 @@
   </div>
   <!-- Right col -->
   <div class="col-md-8">
-    <h2 class="col-md-12">{{model.demo.name}}<a ng-show="model.user.isWriter()" class="btn btn-primary btn-xs btn-editDemo" ng-href="/edit{{model.uri}}" ><span class="glyphicon glyphicon-edit"></span> Edit</a></h2>
+    <h2 class="col-md-12">{{model.demo.name}}<a ng-show="model.user.isWriter()" class="btn btn-primary btn-xs btn-editDemo" ng-href="/edit{{model.uri}}" ><span class="glyphicon glyphicon-edit"></span> Edit</a>
+      <a class="btn btn-success btn-xs btn-follow" href="#"  data-toggle="tooltip" title="Receive emails when this demo is updated" ng-hide="isFollowing()">
+        <i class="fa fa-envelope"></i> Follow this demo</a>
+      <a href="#" class="btn btn-danger btn-xs btn-follow"  data-toggle="tooltip" title="Stop receiving emails when this demo is updated" ng-show="isFollowing()">
+        <i class="fa fa-envelope"></i> Unfollow this demo</a>
+    </h2>
     <div class="desc col-md-12" ng-bind-html="model.demo.description"></div>
-    
+
     <div class="memos col-md-12">
       <h3>Memos</h3>
       <button class="btn btn-primary btn-sm" ng-show="model.user.isWriter()" ng-click="addMemo()">Add</button>

--- a/ui/app/views/demo.html
+++ b/ui/app/views/demo.html
@@ -61,9 +61,9 @@
   <!-- Right col -->
   <div class="col-md-8">
     <h2 class="col-md-12">{{model.demo.name}}<a ng-show="model.user.isWriter()" class="btn btn-primary btn-xs btn-editDemo" ng-href="/edit{{model.uri}}" ><span class="glyphicon glyphicon-edit"></span> Edit</a>
-      <a class="btn btn-success btn-xs btn-follow" href="#"  data-toggle="tooltip" title="Receive emails when this demo is updated" ng-hide="isFollowing()">
+      <a class="btn btn-success btn-xs btn-follow" data-toggle="tooltip" title="Receive emails when this demo is updated" ng-hide="isFollowing()" ng-click="follow()">
         <i class="fa fa-envelope"></i> Follow this demo</a>
-      <a href="#" class="btn btn-danger btn-xs btn-follow"  data-toggle="tooltip" title="Stop receiving emails when this demo is updated" ng-show="isFollowing()">
+      <a class="btn btn-danger btn-xs btn-follow"  data-toggle="tooltip" title="Stop receiving emails when this demo is updated" ng-show="isFollowing()" ng-click="unfollow()">
         <i class="fa fa-envelope"></i> Unfollow this demo</a>
     </h2>
     <div class="desc col-md-12" ng-bind-html="model.demo.description"></div>

--- a/ui/app/views/profile.html
+++ b/ui/app/views/profile.html
@@ -48,20 +48,4 @@
       </div>
     </div>
   </form>
-  <div class="row">
-    <div class="col-sm-2"></div>
-    <h2 class="col-sm-10">Following Demos</h2>
-  </div>
-  <div class="form-group">
-    <div class="row">
-      <label class="col-sm-2 control-label">Demo(s)</label>
-      <div class="col-sm-6">
-        <div class="row" ng-repeat="follow in model.user.follows track by $index">
-          <div class="col-sm-offset-2 col-sm-6">
-          {{follow.title}}
-        </div>
-      </div>
-      </div>
-    </div>
-  </div>
 </div>

--- a/ui/app/views/profile.html
+++ b/ui/app/views/profile.html
@@ -48,4 +48,20 @@
       </div>
     </div>
   </form>
+  <div class="row">
+    <div class="col-sm-2"></div>
+    <h2 class="col-sm-10">Following Demos</h2>
+  </div>
+  <div class="form-group">
+    <div class="row">
+      <label class="col-sm-2 control-label">Demo(s)</label>
+      <div class="col-sm-6">
+        <div class="row" ng-repeat="follow in model.user.follows track by $index">
+          <div class="col-sm-offset-2 col-sm-6">
+          {{follow.title}}
+        </div>
+      </div>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
Add the ability to follow a demo using Alerting.  

* New bootstrap will be required to configure fast reverse searches.
* app_specific.rb has a new function, setup_alerting, to create the Alerting config, trigger, and action for email alerts.  This must be run to configure Alerting for this issue.

Add two buttons to control following and unfollowing a demo to demo.html.  Display the proper one based on if the logged in user is following the current demo (or not).  Clicking Follow POSTs to the new follow REST endpoint and then creates and persists the Alerting rule and also saves information to the user profile.  Unfollow DELETEs the rule and removes the entry from the user's profile.  