### PR TITLE
Fixed #161: preserved search query and model using a factory

### DIFF
--- a/ui/app/search/search-ctrl.js
+++ b/ui/app/search/search-ctrl.js
@@ -2,28 +2,36 @@
   'use strict';
 
   angular.module('demoCat.search')
-    .controller('SearchCtrl', ['$scope', '$location', 'MLSearchFactory', 'MLRemoteInputService', function ($scope, $location, searchFactory, remoteInput) {
-      var mlSearch = searchFactory.newContext(),
-          model = {
-            page: 1,
-            qtext: '',
-            search: {},
-            user: null,
-            selected: []
-          };
+    .factory('SearchModel', ['MLSearchFactory', function(searchFactory) {
+      var mlSearch = searchFactory.newContext();
+      return {
+        page: 1,
+        qtext: '',
+        search: {},
+        user: null,
+        selected: [],
+        mlSearch: mlSearch
+      };
+    }])
+    .controller('SearchCtrl', ['$scope', 'SearchModel', '$location', 'MLRemoteInputService', function ($scope, model, $location, remoteInput) {
+      var mlSearch = model.mlSearch;
 
       (function init() {
+        model.qtext = model.qtext || '';
+        
         // wire up remote input subscription
         remoteInput.initCtrl($scope, model, mlSearch, search);
 
-        // capture initial URL params in mlSearch and ctrl model
-        mlSearch.fromParams().then(function() {
-          // if there was remote input, capture it instead of param
-          if (model.qtext && model.qtext.length)  {
-            mlSearch.setText(model.qtext);
-          }
-          updateSearchResults({});
-        });
+        if (!model.search.results) {
+          // capture initial URL params in mlSearch and ctrl model
+          mlSearch.fromParams().then(function() {
+            // if there was remote input, capture it instead of param
+            if (model.qtext && model.qtext.length)  {
+              mlSearch.setText(model.qtext);
+            }
+            updateSearchResults({});
+          });
+        }
 
         // capture URL params (forward/back, etc.)
         $scope.$on('$locationChangeSuccess', function(e, newUrl, oldUrl){


### PR DESCRIPTION
Interestingly, the logo is using a href="/", kind of causing a full page reload. However, clicking it from details does restore the search. Clicking it a second time resets the search. Unexpected side-effect, but a useful one.

We may need to change href into ng-href for other reasons, and then we will need a separate button to reset the search in one click..