### PR TITLE
Increase timeout to 10 seconds for login call

### DIFF
--- a/server.js
+++ b/server.js
@@ -163,7 +163,7 @@ exports.buildExpress = function(options) {
     login.end();
 
     login.on('socket', function (socket) {
-      socket.setTimeout(1000);
+      socket.setTimeout(10000);
       socket.on('timeout', function() {
         console.log('timeout..');
         login.abort();


### PR DESCRIPTION
Looking at the demo-cat.log file we are getting numerous 'login failed: Error: socket hang up' entries. 