### PR TITLE
Allow search to be cleared

### DIFF
--- a/ui/app/search/search-ctrl.js
+++ b/ui/app/search/search-ctrl.js
@@ -93,7 +93,6 @@
           model.qtext = qtext;
         }
 
-        model.qtext = model.qtext || mlSearch.getText();
         model.page = model.page || mlSearch.getPage();
 
         mlSearch


### PR DESCRIPTION
Fixes #266

This line was setting qtext back to mlSearch.getText() when the qtext
was the empty string. I don't think this line is necessary. After
removing it, #256 is still fixed.

In the absence of a reason for it, which I don't see, let's just remove
it.